### PR TITLE
rama/checkout: se implemento CRUD basico

### DIFF
--- a/Backend/Controllers/checkoutController.js
+++ b/Backend/Controllers/checkoutController.js
@@ -1,0 +1,64 @@
+import { checkoutModel } from "../Models/checkoutModel.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
+import {
+  validateCheckout,
+  validatePartialCheckout,
+} from "../schemas/checkout.js";
+
+export class checkoutController {
+  static getCheckouts = async (req, res) => {
+    const items = await checkoutModel.getCheckouts();
+    res.status(200).json(items);
+  };
+
+  static getCheckoutById = async (req, res) => {
+    const item = await checkoutModel.getCheckoutById(req.params.id);
+    if (item) {
+      res.status(200).json(item);
+    } else {
+      res.status(404).json({ message: "Check-out no encontrado" });
+    }
+  };
+
+  static createCheckout = async (req, res) => {
+    const data = req.body.checkout;
+    const parsed = validateCheckout(data);
+    if (!parsed.success) {
+      return res.status(400).json({ errors: parsed.error.errors });
+    }
+    const result = await checkoutModel.createCheckout(parsed.data);
+    res.status(201).json(result);
+  };
+
+  static updateCheckout = async (req, res) => {
+    const id = req.params.id;
+    const data = req.body.checkout;
+    const parsed = validatePartialCheckout(data);
+    if (!parsed.success) {
+      return res.status(400).json({ errors: parsed.error.errors });
+    }
+    const result = await checkoutModel.updateCheckout(id, parsed.data);
+    if (result.affectedRows > 0) {
+      res.status(200).json({ message: "Check-out actualizado" });
+    } else {
+      res.status(404).json({ message: "Check-out no encontrado" });
+    }
+  };
+
+  static deleteCheckout = async (req, res) => {
+    const result = await checkoutModel.deleteCheckout(req.params.id);
+    if (result.affectedRows > 0) {
+      res.status(200).json({ message: "Check-out eliminado" });
+    } else {
+      res.status(404).json({ message: "Check-out no encontrado" });
+    }
+  };
+}
+
+export const Checkout = {
+  getCheckouts: asyncHandler(checkoutController.getCheckouts),
+  getCheckoutById: asyncHandler(checkoutController.getCheckoutById),
+  createCheckout: asyncHandler(checkoutController.createCheckout),
+  updateCheckout: asyncHandler(checkoutController.updateCheckout),
+  deleteCheckout: asyncHandler(checkoutController.deleteCheckout),
+};

--- a/Backend/Models/checkoutModel.js
+++ b/Backend/Models/checkoutModel.js
@@ -1,0 +1,57 @@
+import { pool } from "../db.js";
+
+export const checkoutModel = {
+  // Obtener todos los check-outs
+  getCheckouts: async () => {
+    const [rows] = await pool.query("SELECT * FROM checkout");
+    return rows;
+  },
+
+  // Obtener un check-out por ID
+  getCheckoutById: async (id) => {
+    const [rows] = await pool.query(
+      "SELECT * FROM checkout WHERE id_checkout = ?",
+      [id]
+    );
+    return rows[0];
+  },
+
+  // Crear un check-out
+  createCheckout: async (data) => {
+    const { id_reserva, descripcion, usuario, fecha, hora } = data;
+    const [result] = await pool.query(
+      `INSERT INTO checkout
+       (id_reserva, descripcion, usuario, fecha, hora)
+       VALUES (?, ?, ?, ?, ?)`,
+      [id_reserva, descripcion || null, usuario, fecha, hora]
+    );
+    return {
+      id: result.insertId,
+      id_reserva,
+      descripcion,
+      usuario,
+      fecha,
+      hora,
+    };
+  },
+
+  // Actualizar un check-out
+  updateCheckout: async (id, data) => {
+    const query = `
+      UPDATE checkout
+      SET ? 
+      WHERE id_checkout = ?
+    `;
+    const [result] = await pool.query(query, [data, id]);
+    return result;
+  },
+
+  // Eliminar un check-out
+  deleteCheckout: async (id) => {
+    const [result] = await pool.query(
+      "DELETE FROM checkout WHERE id_checkout = ?",
+      [id]
+    );
+    return result;
+  },
+};

--- a/Backend/Routes/check-outRoutes.js
+++ b/Backend/Routes/check-outRoutes.js
@@ -1,0 +1,12 @@
+import { Router } from "express";
+import { Checkout } from "../Controllers/checkoutController.js";
+
+const checkoutRouter = Router();
+
+checkoutRouter.get("/", Checkout.getCheckouts);
+checkoutRouter.get("/:id", Checkout.getCheckoutById);
+checkoutRouter.post("/", Checkout.createCheckout);
+checkoutRouter.put("/:id", Checkout.updateCheckout);
+checkoutRouter.delete("/:id", Checkout.deleteCheckout);
+
+export default checkoutRouter;

--- a/Backend/Routes/indexRoutes.js
+++ b/Backend/Routes/indexRoutes.js
@@ -7,6 +7,8 @@ import tempodasRouter from "./temporadasRoutes.js"; // Importar el router de tem
 //paso 4 importar el router de habitaciones
 import habitacionesRouter from "./habitacionesRoutes.js";
 import promocionesRouter from "./promocionesRoutes.js"; // Importar el router de promociones
+import checkoutRouter from "./check-outRoutes.js"; // Importar el router de check-out
+// Importar el router de check-out
 
 const router = Router();
 
@@ -23,6 +25,8 @@ router.use('/Habitaciones', habitacionesRouter)
 router.use('/Temporadas', tempodasRouter) // Usar el router de temporadas
 
 router.use('/Promociones',promocionesRouter) // Usar el router de promociones
+
+router.use('/Checkout',checkoutRouter) // Usar el router de check-out
 
 //visualiza 404 con cualquier ruta no definida
 router.use((req, res, next) => {

--- a/Backend/schemas/checkout.js
+++ b/Backend/schemas/checkout.js
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+const mysqlDateRegex = /^\d{4}-\d{2}-\d{2}$/;
+const mysqlTimeRegex = /^\d{2}:\d{2}:\d{2}$/;
+
+export const checkoutSchema = z.object({
+  id_reserva: z
+    .number()
+    .int()
+    .positive("ID de reserva inválido"),
+  
+  descripcion: z
+    .string()
+    .optional(),
+  
+  usuario: z
+    .boolean({
+      required_error: "Se debe indicar si es usuario",
+      invalid_type_error: "Debe ser un valor booleano (true/false)"
+    }),
+  
+  fecha: z
+    .string()
+    .regex(mysqlDateRegex, "Formato de fecha inválido, debe ser YYYY-MM-DD"),
+  
+  hora: z
+    .string()
+    .regex(mysqlTimeRegex, "Formato de hora inválido, debe ser HH:mm:ss")
+});
+
+export function validateCheckout(data) {
+  return checkoutSchema.safeParse(data);
+}
+
+export function validatePartialCheckout(data) {
+  return checkoutSchema.partial().safeParse(data);
+}


### PR DESCRIPTION
Este PR añade el módulo básico de Check-out, de forma paralela al de Check-in:

Modelo (checkoutModel.js)

Métodos getCheckouts, getCheckoutById, createCheckout, updateCheckout y deleteCheckout implementados con SQL puro vía pool.query.

Esquema Zod (schemas/checkout.js)

Validaciones de entrada:

id_reserva: entero positivo

usuario: booleano

fecha: formato YYYY-MM-DD

hora: formato HH:mm:ss

descripcion: opcional

Controlador (checkoutController.js)

Acciones expuestas con asyncHandler para manejo de errores asíncronos.

Uso de validateCheckout y validatePartialCheckout para validar datos en creación y actualización.

Rutas REST (checkoutRoutes.js)

Endpoints:

GET /checkouts

GET /checkouts/:id

POST /checkouts

PUT /checkouts/:id

DELETE /checkouts/:id